### PR TITLE
Change to strategic merge and improve error handling in patch deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "kube-environment"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -926,9 +926,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "lock_api"
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kube-environment"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -17,7 +17,7 @@ const FIELD_MANAGER: &str = "kube-environment";
 lazy_static! {
     static ref PATCH_PARAMS: PatchParams = PatchParams {
         dry_run: false,
-        force: true,
+        force: false,
         field_manager: Some(String::from(FIELD_MANAGER)),
         field_validation: Some(ValidationDirective::Strict),
     };
@@ -59,7 +59,13 @@ pub(crate) async fn deploy(
         Ok(patched) => Ok(Json(deployment_to_json(patched))),
         Err(e) => {
             tracing::error!(error =%e, "failed to patch deployment");
-            Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+            match e {
+                KubeError::Api(response) => match StatusCode::from_u16(response.code) {
+                    Ok(status_code) => Err((status_code, response.message).into_response()),
+                    Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+                },
+                _ => Err(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+            }
         }
     }
 }
@@ -112,7 +118,7 @@ async fn patch_deployment_image(
         }
     });
     deployment_api
-        .patch(deployment_name, &PATCH_PARAMS, &Patch::Apply(patch))
+        .patch(deployment_name, &PATCH_PARAMS, &Patch::Strategic(patch))
         .await
 }
 


### PR DESCRIPTION
In src/controllers.rs, error handling has been improved in the patch deployment process. Now, if a 'patch deployment' action fails, it returns the appropriate status code and message from the Kubernetes API instead of only returning an internal server error. This will provide more helpful error information for the client and debug. Also, the patch strategy was changed to 'Strategic' for more flexibility.