### PR TITLE
Fix artifacts upload action in GitHub workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -92,8 +92,8 @@ jobs:
           cross-version: ${{ matrix.info.cross-version || '0.2.5' }}
 
       - uses: actions/upload-artifact@v4
-        name: artifact ${{ matrix.info.target }}
         with:
+          name: artifact ${{ matrix.info.target }}
           path: |
             target/*/release/kube-environment
             target/*/release/kube-environment.exe


### PR DESCRIPTION
This commit corrects the ordering in the `actions/upload-artifact` clause of the GitHub workflow file, also adjusting the `with` argument field to properly assign names to the artifacts.